### PR TITLE
Add version specification to biopython install.

### DIFF
--- a/AFcluster.ipynb
+++ b/AFcluster.ipynb
@@ -73,7 +73,7 @@
         "\n",
         "if [ ! -d alphafold ]; then\n",
         "  git clone https://github.com/deepmind/alphafold.git\n",
-        "  ! pip -q install ml-collections dm-haiku biopython\n",
+        "  ! pip -q install ml-collections dm-haiku biopython==1.81\n",
         "fi\n",
         "\n",
         "if [ ! -d output ]; then\n",


### PR DESCRIPTION
Biopython 1.83+ no longer has Bio.data.SCOPdata which is required by AF2. Rolling back to 1.81 fixes errors caused by the lack of this module.