### PR TITLE
🐞 fix: TSNE now encodes query sequence correctly +++ fixed types in C…

### DIFF
--- a/scripts/ClusterMSA.py
+++ b/scripts/ClusterMSA.py
@@ -50,10 +50,10 @@ if __name__=='__main__':
     p.add_argument('--eps_val', action='store', type=float, help="Use single value for eps instead of scanning.")
     p.add_argument('--resample', action='store_true', help='If included, will resample the original MSA with replacement before writing.')
     p.add_argument("--gap_cutoff", action='store', type=float, default=0.25, help='Remove sequences with gaps representing more than this frac of seq.')
-    p.add_argument('--min_eps', action='store',default=3, help='Min epsilon value to scan for DBSCAN (Default 3).')
-    p.add_argument('--max_eps', action='store',default=20, help='Max epsilon value to scan for DBSCAN (Default 20).')
-    p.add_argument('--eps_step', action='store',default=.5, help='step for epsilon scan for DBSCAN (Default 0.5).')
-    p.add_argument('--min_samples', action='store',default=3, help='Default min_samples for DBSCAN (Default 3, recommended no lower than that).')
+    p.add_argument('--min_eps', action='store',default=3, type=int, help='Min epsilon value to scan for DBSCAN (Default 3).')
+    p.add_argument('--max_eps', action='store',default=20, type=int, help='Max epsilon value to scan for DBSCAN (Default 20).')
+    p.add_argument('--eps_step', action='store',default=.5, type=float, help='step for epsilon scan for DBSCAN (Default 0.5).')
+    p.add_argument('--min_samples', action='store',default=3, type=int, help='Default min_samples for DBSCAN (Default 3, recommended no lower than that).')
 
     p.add_argument('--run_PCA', action='store_true', help='Run PCA on one-hot embedding of sequences and store in output_cluster_metadata.tsv')
     p.add_argument('--run_TSNE', action='store_true', help='Run TSNE on one-hot embedding of sequences and store in output_cluster_metadata.tsv')
@@ -197,7 +197,7 @@ if __name__=='__main__':
 
     if args.run_TSNE:
         lprint('Running TSNE ...',f)
-        ohe_vecs = encode_seqs(df.sequence.tolist()+[query_.sequence.tolist()], max_len=L)
+        ohe_vecs = encode_seqs(df.sequence.tolist()+query_.sequence.tolist(), max_len=L)
         # different than PCA because tSNE doesn't have .transform attribute
 
         mdl = TSNE()


### PR DESCRIPTION
Hi There

Even though it looks like the repo is pretty stale at this point, I still would like to submit a fix for a bug that I found when it comes to computing the TSNE in the script `ClusterMSA.py`. Specifically, in line `200` the sequences are converted to lists and and subsequently added together. However, the `query_.sequence.tolist()` is itself wrapped inside square brackets which causes it to be another list. As a consequence, the final inputs for the `encode_seqs` call contain a single-entry list as final element (i.e. the one for the query sequence) rather than a string. Therefore the encoding does not work properly for this case, which lets the query sequence also appear in a wrong location in the TSNE plot. 

```diff
[line 200 in scripts/ClusterMSA.py]
- ohe_vecs = encode_seqs(df.sequence.tolist()+[query_.sequence.tolist()], max_len=L)
+ ohe_vecs = encode_seqs(df.sequence.tolist()+query_.sequence.tolist(), max_len=L)
```

<details> 
<summary>What the inputs actually look like</summary>

```python
>>> inputs_original = df.sequence.tolist()+[query_.sequence.tolist()]
>>> print(inputs_original[-5:]) # (notice the list in the final element)
['--LVINDRNGRHCSMNVKLSDTIGNLKANI---PSIDPQNKELVFNDMVLDDTCILANLPIMADSILTLM------',
 '-KVKVKPLEGSVFELSINASETVDMVKHRICAREGVNSQVHALCFEGRELPPGSLMSRSG----------------',
 '-QIYVKSLLSKAFVVEMLTYDTVGMLKARIQKNFKLPIEKL-LTLEETPLEDNAKLEHTVISNDSAI---------',
 '----------QMITMAFNINQSVGKLKQYFASQLKVPQDVLQVVFQGRLIEDGESLMHIGVRPHGTIQ--------',
 ['MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG']]


>>> inputs_fixed = df.sequence.tolist()+query_.sequence.tolist()
>>> print(inputs_fixed[-5:])
['--LVINDRNGRHCSMNVKLSDTIGNLKANI---PSIDPQNKELVFNDMVLDDTCILANLPIMADSILTLM------',
 '-KVKVKPLEGSVFELSINASETVDMVKHRICAREGVNSQVHALCFEGRELPPGSLMSRSG----------------',
 '-QIYVKSLLSKAFVVEMLTYDTVGMLKARIQKNFKLPIEKL-LTLEETPLEDNAKLEHTVISNDSAI---------',
 '----------QMITMAFNINQSVGKLKQYFASQLKVPQDVLQVVFQGRLIEDGESLMHIGVRPHGTIQ--------',
 'MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG']
```

</details>

As a simple test to exemplify this, run the following (with any arbitrary a3m you have lying around as input)

```python
original_ohe = encode_seqs(df.sequence.tolist()+[query_.sequence.tolist()], max_len=L)
fixed_ohe = encode_seqs(df.sequence.tolist()+query_.sequence.tolist(), max_len=L)

# since we do one-hot encoding every entry should have at least one 1-valued entry
assert original_ohe.any(axis=1).all(), "Encoding in the original setup does not work since there are all-0 entries!"
# will raise AssertationError
assert fixed_ohe.any(axis=1).all(), "Encoding in the fixed setup does not work since there are all-0 entries!"
# will be fine
```


Also, I found that when submitting custom values to the command line interface for arguments like `min_samples` they were retained as `str` even though the defaults were numeric. Therefore, I added type declarations to the CLI for 
- min_eps
- max_eps
- eps_step
- min_samples

to ensure that the values are properly converted.

Cheers, 
Noah ☀️
